### PR TITLE
改善移动端布局

### DIFF
--- a/src/app/layout/header/header.component.scss
+++ b/src/app/layout/header/header.component.scss
@@ -12,6 +12,12 @@
   top: 0;
   width: 100%;
   z-index: 10;
+  @media (max-width: 50em) {
+    position: static;
+    height: auto;
+    flex-direction: column;
+  }
+
   &-img {
     width: 40px;
     height: 40px;

--- a/src/app/page/gvg/gvg/gvg.component.scss
+++ b/src/app/page/gvg/gvg/gvg.component.scss
@@ -24,6 +24,12 @@ pcr-ellipsis-text {
     .ant-btn:not(:first-child) {
       margin-left: 10px;
     }
+    @media (max-width: 50em) {
+      flex-direction: column-reverse;
+      &>:not(:last-child) {
+        margin-top: 1em;
+      }
+    }
   }
 
   .ant-form-item {


### PR DESCRIPTION
目前的样式在移动端，比如手机上观看会比较费劲，微调改善了一些比较痛的地方。

对比图如下：

![g2453](https://user-images.githubusercontent.com/3102803/198845087-5d93fb6d-8fda-4b37-a697-97d6e62642ce.jpg)
![g2473](https://user-images.githubusercontent.com/3102803/198845089-20e085bd-06d5-4bcc-b35e-a19fb85a12bf.jpg)

感谢各位对项目的付出，拯救了我的会战（